### PR TITLE
Remove underline on links

### DIFF
--- a/src/assets/scss/theme/_a.scss
+++ b/src/assets/scss/theme/_a.scss
@@ -1,7 +1,7 @@
 a {
   color: $link-color;
   background-color: transparent;
-  -webkit-text-decoration-skip: objects;
+  text-decoration: none;
 
   &:focus, &:hover, &:active {
     color: darken($link-color, 10%);


### PR DESCRIPTION
I don't have a strong sense of which way this one should go. Underline helps for vision impaired individuals, so I left it in initially, however, it doesn't look very good, especially on the search results where there are so many links. I'll merge this after approval so we can revert if the decision is made the other way.