### PR TITLE
get provider and services separately from api.js

### DIFF
--- a/src/pages/service.js
+++ b/src/pages/service.js
@@ -37,27 +37,8 @@ export default class Service extends Component {
   componentDidMount = () => {
     const { id } = this.props.match.params;
 
-    loadService(id).then(providers => {
-
-      // The API can return a list of results, including a duplicate for each
-      // type of service offered by the organisation or even other organisations
-      // which are (somehow) related.
-      //
-      // The provider object from the API has properties including fsdId, FSDID
-      // and FSD_ID. In the examples I've seen the fsdId and FSDID can apply to
-      // multiple providers, but the FSD_ID specifies the provider we were
-      // expecting. Also the FSD_ID is the first field returned in the server
-      // response which implies it's the primary key.
-      //
-      // It's also worth noting that the records which describe additional
-      // services from the same provider are being ignored currently, and the
-      // details for whichever service is arbitrarily listed first are
-      // displayed. TODO render the services in a list.
-      const selectAppropriateResult = (fsdId, providers) => {
-        return providers.filter(r => r.FSD_ID === Number(fsdId))[0]
-      }
-
-      const provider = selectAppropriateResult(id, providers);
+    loadService(id).then(args => {
+      const {provider, services} = args
 
       this.setState({
         loading: false,
@@ -70,21 +51,15 @@ export default class Service extends Component {
         email: provider.PUBLISHED_CONTACT_EMAIL_1,
         phoneNumber: provider.PUBLISHED_PHONE_1,
 
-        serviceName: provider.SERVICE_NAME,
-        targetAudiences: provider.SERVICE_TARGET_AUDIENCES,
-        deliveryMethods: provider.DELIVERY_METHODS,
-        serviceReferrals: provider.SERVICE_REFERRALS,
-        costType: provider.COST_TYPE,
-        costDescription: provider.COST_DESCRIPTION,
-        serviceDetail: provider.SERVICE_DETAIL,
+        //TODO this is limited to only showing one service until the page design
+        //is updated
+        services: services.slice(0, 1),
 
         latitude: provider.LATITUDE,
         longitude: provider.LONGITUDE
       });
     });
   };
-
-
 
   render() {
     const { match: {params: {id}}, history: {goBack} } = this.props;
@@ -99,13 +74,7 @@ export default class Service extends Component {
       email,
       phoneNumber,
 
-      serviceName,
-      targetAudiences,
-      deliveryMethods,
-      serviceReferrals,
-      costType,
-      costDescription,
-      serviceDetail,
+      services,
 
       latitude,
       longitude
@@ -142,15 +111,18 @@ export default class Service extends Component {
                 phoneNumber={phoneNumber}
                 hideMoreDetails={true}
               />
-              <ServiceDetails
-                serviceName={serviceName}
-                targetAudiences={targetAudiences}
-                deliveryMethods={deliveryMethods}
-                serviceReferrals={serviceReferrals}
-                costType={costType}
-                costDescription={costDescription}
-                serviceDetail={serviceDetail}
-              />
+              {services.map((service, i) =>
+                <ServiceDetails
+                  key={i}
+                  serviceName={service.SERVICE_NAME}
+                  targetAudiences={service.SERVICE_TARGET_AUDIENCES}
+                  deliveryMethods={service.DELIVERY_METHODS}
+                  serviceReferrals={service.SERVICE_REFERRALS}
+                  costType={service.COST_TYPE}
+                  costDescription={service.COST_DESCRIPTION}
+                  serviceDetail={service.SERVICE_DETAIL}
+                />
+              )}
               <MapContainer serviceProviders={mapPoint} />
             </Fragment>
           )}


### PR DESCRIPTION
Bug: visiting `service/18197` should show Connecting Communities Wairarapa but instead shows a result for WINZ. (This example is the first result if you do a location search for `Wellington Region`)

This is caused by the API returning a list of results which includes providers other than the one we expected, and the existing code displays the first provider from the result set. The result set can be filtered to exclude the other providers, although it's not clear why they were included in the first place.

Internally this PR changes the API query on the service page so it will return a single (correct) provider object and a list of service objects which are supplied by that provider. The service list is currently sliced to only display the first available service (existing behaviour, so the page doesn't look weird) but it seems like we'll want to show all of them in an accordion or something.
